### PR TITLE
Added Access Grants Cache and Access Denied Cache

### DIFF
--- a/boto3-s3-access-grants-plugin/cache/access_denied_cache.py
+++ b/boto3-s3-access-grants-plugin/cache/access_denied_cache.py
@@ -1,0 +1,20 @@
+from cacheout import Cache
+
+ACCESS_DENIED_CACHE_SIZE = 3000
+ACCESS_DENIED_CACHE_TTL = 5 * 60   # 5 mins
+
+
+class AccessDeniedCache:
+    access_denied_cache = None
+
+    def __init__(self, cache_size=ACCESS_DENIED_CACHE_SIZE, ttl=ACCESS_DENIED_CACHE_TTL):
+        self.cache_size = cache_size
+        self.ttl = ttl
+
+        self.access_denied_cache = Cache(maxsize=self.cache_size, ttl=self.ttl)
+
+    def put_value_in_cache(self, key, value):
+        return self.access_denied_cache.set(key, value)
+
+    def get_value_from_cache(self, key):
+        return self.access_denied_cache.get(key)

--- a/boto3-s3-access-grants-plugin/cache/access_grants_cache.py
+++ b/boto3-s3-access-grants-plugin/cache/access_grants_cache.py
@@ -1,0 +1,116 @@
+from cacheout import Cache
+import logging
+from botocore.exceptions import ClientError
+from account_id_resolver_cache import AccountIdResolverCache
+from cache_key import CacheKey
+import sys
+
+sys.path.append("..")
+sys.path.insert(0, "boto3-s3-access-grants-plugin")
+from exceptions import IllegalArgumentException
+
+DEFAULT_ACCESS_GRANTS_CACHE_SIZE = 30000
+MAX_LIMIT_ACCESS_GRANTS_CACHE_SIZE = 1000000
+GET_DATA_ACCESS_DURATION = 1 * 60 * 60  # 1 hour
+MAX_GET_DATA_ACCESS_DURATION = 12 * 60 * 60    # 12 hours
+CACHE_EXPIRATION_TIME_PERCENTAGE = 90
+
+
+class AccessGrantsCache:
+    access_grants_cache = None
+    account_id_resolver_cache = AccountIdResolverCache()
+
+    def __init__(self, cache_size=DEFAULT_ACCESS_GRANTS_CACHE_SIZE,
+                 duration=GET_DATA_ACCESS_DURATION):
+        self.cache_size = cache_size
+        self.duration = duration
+        self.cache_ttl = (duration * CACHE_EXPIRATION_TIME_PERCENTAGE) / 100
+
+        if self.cache_size > MAX_LIMIT_ACCESS_GRANTS_CACHE_SIZE:
+            raise IllegalArgumentException(
+                "Max cache size should be less than or equal to " + str(MAX_LIMIT_ACCESS_GRANTS_CACHE_SIZE))
+
+        if self.duration > GET_DATA_ACCESS_DURATION:
+            raise IllegalArgumentException("Maximum duration should be less than or equal to " + str(
+                GET_DATA_ACCESS_DURATION))
+
+        self.access_grants_cache = Cache(maxsize=self.cache_size, ttl=self.cache_ttl)
+
+    #  This is for grants of type "s3://bucket/prefix/*"
+    def __search_credentials_at_prefix_level(self, cache_key):
+
+        prefix = cache_key.s3_prefix
+        while prefix != "s3:":
+            cache_key = CacheKey(cache_key=cache_key, s3_prefix=prefix)
+            cache_value = self.access_grants_cache.get(cache_key)
+            if cache_value is not None:
+                logging.debug("Successfully retrieved credentials from cache.")
+                return cache_value
+            prefix = prefix.rsplit('/', 1)[0]
+        return None
+
+    # This is for grants of type "s3://bucket/prefix*"
+    def __search_credentials_at_character_level(self, cache_key):
+        prefix = cache_key.s3_prefix
+        while prefix != "s3://":
+            cache_key = CacheKey(cache_key=cache_key, s3_prefix=prefix + "*")
+            cache_value = self.access_grants_cache.get(cache_key)
+            if cache_value is not None:
+                logging.debug("Successfully retrieved credentials from cache.")
+                return cache_value
+            prefix = prefix[:-1]
+        return None
+
+    def __get_credentials_from_service(self, s3_control_client, cache_key, account_id):
+        if s3_control_client is None:
+            raise IllegalArgumentException("S3 Control Client should not be null")
+        bucket_owner_account_id = self.account_id_resolver_cache.resolve(s3_control_client, account_id,
+                                                                         cache_key.s3_prefix)
+        logging.debug((
+                "Fetching credentials from Access Grants for accountId: " + bucket_owner_account_id + ", s3Prefix: " + cache_key.s3_prefix +
+                ", permission: " + cache_key.permission + ", privilege: " + "DEFAULT"))
+        return s3_control_client.get_data_access(AccountId=bucket_owner_account_id, Target=cache_key.s3_prefix,
+                                                 Permission=cache_key.permission, Privilege='Default')
+
+    # This method removes '/*' from matchedGrantTarget if present.
+    # This helps us differentiate between grants of type "s3://bucket/prefix/*" and "s3://bucket/prefix*".
+    @staticmethod
+    def __process_matched_target(matched_grant_target):
+        if matched_grant_target.endswith("/*"):
+            return matched_grant_target[:-2]
+        return matched_grant_target
+
+    def get_credentials(self, s3_control_client, cache_key, account_id, access_denied_cache):
+        credentials = self.__search_credentials_at_prefix_level(cache_key)
+        if credentials is None and (cache_key.permission == "READ" or cache_key.permission == "WRITE"):
+            credentials = self.__search_credentials_at_prefix_level(CacheKey(permission="READWRITE", cache_key=cache_key))
+        if credentials is None:
+            credentials = self.__search_credentials_at_character_level(cache_key)
+        if credentials is None and (cache_key.permission == "READ" or cache_key.permission == "WRITE"):
+            credentials = self.__search_credentials_at_character_level(
+                CacheKey(permission="READWRITE", cache_key=cache_key))
+        if credentials is None:
+            logging.debug("No credentials found in cache. Fetching from service")
+            try:
+                response = self.__get_credentials_from_service(s3_control_client, cache_key, account_id)
+                credentials = response["Credentials"]
+                matched_grant_target = response["MatchedGrantTarget"]
+                if matched_grant_target.endswith("*"):      # we do not cache object level grants
+                    self.access_grants_cache.set(
+                        CacheKey(s3_prefix=AccessGrantsCache.__process_matched_target(matched_grant_target),
+                                 cache_key=cache_key), credentials)
+                logging.debug("Successfully retrieved credentials from service.")
+            except ClientError as e:
+                if e.response["Error"]["Code"] == "AccessDenied":
+                    access_denied_cache.put_value_in_cache(cache_key, e)
+                    print(e)
+                raise e
+        return credentials
+
+    def __put_value_in_cache(self, cache_key, value):
+        return self.access_grants_cache.set(cache_key,value)
+
+    def __get_value_from_cache(self, cache_key):
+        return self.access_grants_cache.get(cache_key)
+
+

--- a/boto3-s3-access-grants-plugin/cache/cache_key.py
+++ b/boto3-s3-access-grants-plugin/cache/cache_key.py
@@ -1,8 +1,24 @@
+from exceptions import IllegalArgumentException
+
+
 class CacheKey:
-    def __init__(self, credentials, permission, s3_prefix):
-        self.credentials = credentials
-        self.permission = permission
-        self.s3_prefix = s3_prefix
+    def __init__(self, credentials=None, permission=None, s3_prefix=None, cache_key=None):
+        if cache_key is None:
+            self.credentials = credentials
+            self.permission = permission
+            self.s3_prefix = s3_prefix
+        else:
+            if permission is not None:
+                self.credentials = cache_key.credentials
+                self.s3_prefix = cache_key.s3_prefix
+                self.permission = permission
+            elif s3_prefix is not None:
+                self.credentials = cache_key.credentials
+                self.permission = cache_key.permission
+                self.s3_prefix = s3_prefix
+
+        if self.credentials is None or self.permission is None or self.s3_prefix is None:
+            raise IllegalArgumentException("Credentials, permission, and s3_prefix must be provided")
 
     def __eq__(self, other):
         return ((self.credentials.access_key, self.credentials.secret_key, self.permission, self.s3_prefix) ==

--- a/boto3-s3-access-grants-plugin/exceptions.py
+++ b/boto3-s3-access-grants-plugin/exceptions.py
@@ -3,6 +3,7 @@ class IllegalArgumentException(Exception):
         self.message = message
         super().__init__(message)
 
+
 class UnsupportedOperationError(Exception):
     def __init__(self, message):
         self.message = message

--- a/tests/unit/cache/test_access_denied_cache.py
+++ b/tests/unit/cache/test_access_denied_cache.py
@@ -1,0 +1,28 @@
+import unittest
+from botocore import credentials
+from botocore.exceptions import ClientError
+from access_denied_cache import AccessDeniedCache
+from cache_key import CacheKey
+
+
+class TestAccessDeniedCache(unittest.TestCase):
+    access_denied_cache = AccessDeniedCache()
+
+    def test_cache_key_equals(self):
+        credentials_1 = credentials.Credentials(access_key="access_key", secret_key="secret_key", token="token")
+        permission_1 = 'READ'
+        s3_prefix_1 = "s3://bucket-name/*"
+        key_1 = CacheKey(credentials_1, permission_1, s3_prefix_1)
+
+        credentials_2 = credentials.Credentials(access_key="access_key", secret_key="secret_key", token="token")
+        permission_2 = 'READ'
+        s3_prefix_2 = "s3://bucket-name/*"
+        key_2 = CacheKey(credentials_2, permission_2, s3_prefix_2)
+
+        error_response = {'Error': {'Message': 'You do not have READWRITE permissions to the requested S3 Prefix: '
+                                               's3://bucket-name/*', 'Code': 'AccessDenied'}}
+        e = ClientError(error_response, "HeadBucket")
+
+        self.access_denied_cache.put_value_in_cache(key_1, e)
+        self.assertIsNotNone(self.access_denied_cache.get_value_from_cache(key_1))
+        self.assertIsNotNone(self.access_denied_cache.get_value_from_cache(key_2))

--- a/tests/unit/cache/test_access_grants_cache.py
+++ b/tests/unit/cache/test_access_grants_cache.py
@@ -1,0 +1,206 @@
+import time
+import unittest
+from datetime import datetime
+import exceptions
+from botocore import credentials
+from access_denied_cache import AccessDeniedCache
+from access_grants_cache import AccessGrantsCache
+from cache_key import CacheKey
+import mock
+
+
+class TestAccessGrantsCache(unittest.TestCase):
+    access_grants_cache = None
+    access_grants_credentials = credentials.Credentials(access_key="access_key", secret_key="secret_key", token="token")
+    mock_s3_control_client = None
+    mock_account_id_resolver_cache = None
+    access_denied_cache = None
+    requester_account_id = "123456789012"
+
+    def setUp(self):
+        self.access_grants_cache = AccessGrantsCache()
+        self.mock_s3_control_client = mock.Mock()
+        self.mock_account_id_resolver_cache = mock.Mock()
+        self.access_denied_cache = AccessDeniedCache()
+
+    def test_cache_hit(self):
+        credentials_1 = credentials.Credentials(access_key="access_key", secret_key="secret_key", token="token")
+        key_1 = CacheKey(credentials_1, 'READ', "s3://bucket-name")
+        credentials_2 = credentials.Credentials(access_key="access_key", secret_key="secret_key", token="token")
+        key_2 = CacheKey(credentials_2, 'READ', "s3://bucket-name")
+
+        self.access_grants_cache._AccessGrantsCache__put_value_in_cache(key_1, self.access_grants_credentials)
+        value_1 = self.access_grants_cache.get_credentials(self.mock_s3_control_client, key_1,
+                                                           self.requester_account_id, self.access_denied_cache)
+        value_2 = self.access_grants_cache.get_credentials(self.mock_s3_control_client, key_2,
+                                                           self.requester_account_id, self.access_denied_cache)
+        self.assertEqual(value_1, value_2)
+
+    def test_cache_hit_for_grant_present_at_higher_prefix(self):
+        credentials_1 = credentials.Credentials(access_key="access_key", secret_key="secret_key", token="token")
+        key_1 = CacheKey(credentials_1, 'READ', "s3://bucket-name")
+        self.access_grants_cache._AccessGrantsCache__put_value_in_cache(key_1, self.access_grants_credentials)
+
+        credentials_2 = credentials.Credentials(access_key="access_key", secret_key="secret_key", token="token")
+        key_2 = CacheKey(credentials_2, 'READ', "s3://bucket-name/prefixA")
+
+        value = self.access_grants_cache.get_credentials(self.mock_s3_control_client, key_2,
+                                                         self.requester_account_id, self.access_denied_cache)
+        self.assertEqual(value, self.access_grants_credentials)
+
+    def test_cache_hit_for_grant_present_at_higher_prefix_at_character_level(self):
+        credentials_1 = credentials.Credentials(access_key="access_key", secret_key="secret_key", token="token")
+        key_1 = CacheKey(credentials_1, 'READ', "s3://bucket-name/P*")
+        self.access_grants_cache._AccessGrantsCache__put_value_in_cache(key_1, self.access_grants_credentials)
+
+        credentials_2 = credentials.Credentials(access_key="access_key", secret_key="secret_key", token="token")
+        key_2 = CacheKey(credentials_2, 'READ', "s3://bucket-name/PrefixA")
+
+        value = self.access_grants_cache.get_credentials(self.mock_s3_control_client, key_2,
+                                                         self.requester_account_id, self.access_denied_cache)
+        self.assertEqual(value, self.access_grants_credentials)
+
+    def test_cache_hit_for_readwrite_grant_for_a_read_request(self):
+        credentials_1 = credentials.Credentials(access_key="access_key", secret_key="secret_key", token="token")
+        key_1 = CacheKey(credentials_1, 'READWRITE', "s3://bucket-name")
+        self.access_grants_cache._AccessGrantsCache__put_value_in_cache(key_1, self.access_grants_credentials)
+
+        credentials_2 = credentials.Credentials(access_key="access_key", secret_key="secret_key", token="token")
+        key_2 = CacheKey(credentials_2, 'READ', "s3://bucket-name/prefixA")
+
+        value = self.access_grants_cache.get_credentials(self.mock_s3_control_client, key_2,
+                                                         self.requester_account_id, self.access_denied_cache)
+        self.assertEqual(value, self.access_grants_credentials)
+
+    @mock.patch('access_grants_cache.AccessGrantsCache._AccessGrantsCache__get_credentials_from_service')
+    def test_cache_miss_for_write_grant_for_a_read_request(self, mocked_get_credentials_from_service):
+        credentials_1 = credentials.Credentials(access_key="access_key", secret_key="secret_key", token="token")
+        key_1 = CacheKey(credentials_1, 'WRITE', "s3://bucket-name")
+        self.access_grants_cache._AccessGrantsCache__put_value_in_cache(key_1, self.access_grants_credentials)
+
+        credentials_2 = credentials.Credentials(access_key="access_key", secret_key="secret_key", token="token")
+        key_2 = CacheKey(credentials_2, 'READ', "s3://bucket-name/prefixA")
+
+        self.access_grants_cache.get_credentials(self.mock_s3_control_client, key_2,
+                                                 self.requester_account_id, self.access_denied_cache)
+        mocked_get_credentials_from_service.assert_called_once()
+
+    @mock.patch('access_grants_cache.AccessGrantsCache._AccessGrantsCache__get_credentials_from_service')
+    def test_cache_miss_for_cache_key_with_different_prefix(self, mocked_get_credentials_from_service):
+        credentials_1 = credentials.Credentials(access_key="access_key", secret_key="secret_key", token="token")
+        key_1 = CacheKey(credentials_1, 'READ', "s3://bucket-name/prefixA")
+        self.access_grants_cache._AccessGrantsCache__put_value_in_cache(key_1, self.access_grants_credentials)
+
+        credentials_2 = credentials.Credentials(access_key="access_key", secret_key="secret_key", token="token")
+        key_2 = CacheKey(credentials_2, 'READ', "s3://bucket-name/prefixB")
+
+        self.access_grants_cache.get_credentials(self.mock_s3_control_client, key_2,
+                                                 self.requester_account_id, self.access_denied_cache)
+
+        mocked_get_credentials_from_service.assert_called_once()
+
+    def test_get_credentials_when_cache_is_empty(self):
+        self.mock_s3_control_client.get_data_access.return_value = {
+            'Credentials': {
+                'AccessKeyId': 'access_key_id',
+                'SecretAccessKey': 'secret_access_key',
+                'SessionToken': 'session_token',
+                'Expiration': datetime(2015, 1, 1)
+            },
+            'MatchedGrantTarget': 'string'
+        }
+
+        self.mock_s3_control_client.get_access_grants_instance_for_prefix.return_value = {
+            'AccessGrantsInstanceArn': 'arn:aws:s3:us-east-2:987654321098:access-grants/default',
+            'AccessGrantsInstanceId': 'abcdefghijklmnopqrstuvwxyz'
+        }
+        requester_credentials = credentials.Credentials(access_key="access_key", secret_key="secret_key", token="token")
+        key = CacheKey(requester_credentials, 'READ', "s3://bucket-name/prefixA")
+        value = self.access_grants_cache.get_credentials(self.mock_s3_control_client, key,
+                                                         self.requester_account_id, self.access_denied_cache)
+
+        access_grants_credentials = {
+            'AccessKeyId': 'access_key_id',
+            'SecretAccessKey': 'secret_access_key',
+            'SessionToken': 'session_token',
+            'Expiration': datetime(2015, 1, 1)
+        }
+        self.assertEqual(access_grants_credentials, value)
+
+    def test_cache_hit_for_different_prefixes_with_same_matched_grant_target(self):
+        self.mock_s3_control_client.get_data_access.return_value = {
+            'Credentials': {
+                'AccessKeyId': 'access_key_id',
+                'SecretAccessKey': 'secret_access_key',
+                'SessionToken': 'session_token',
+                'Expiration': datetime(2015, 1, 1)
+            },
+            'MatchedGrantTarget': 's3://bucket-name/*'
+        }
+
+        self.mock_s3_control_client.get_access_grants_instance_for_prefix.return_value = {
+            'AccessGrantsInstanceArn': 'arn:aws:s3:us-east-2:987654321098:access-grants/default',
+            'AccessGrantsInstanceId': 'abcdefghijklmnopqrstuvwxyz'
+        }
+        requester_credentials = credentials.Credentials(access_key="access_key", secret_key="secret_key", token="token")
+        key_1 = CacheKey(requester_credentials, 'READ', "s3://bucket-name/prefixA")
+        key_2 = CacheKey(requester_credentials, 'READ', "s3://bucket-name/prefixB")
+        self.access_grants_cache.get_credentials(self.mock_s3_control_client, key_1,
+                                                 self.requester_account_id, self.access_denied_cache)
+        self.access_grants_cache.get_credentials(self.mock_s3_control_client, key_2,
+                                                 self.requester_account_id, self.access_denied_cache)
+        self.assertEqual(self.mock_s3_control_client.get_data_access.call_count, 1)
+
+    def test_object_level_grant_is_not_stored_in_cache(self):
+        self.mock_s3_control_client.get_data_access.return_value = {
+            'Credentials': {
+                'AccessKeyId': 'access_key_id',
+                'SecretAccessKey': 'secret_access_key',
+                'SessionToken': 'session_token',
+                'Expiration': datetime(2015, 1, 1)
+            },
+            'MatchedGrantTarget': 's3://bucket-name/prefixA'
+        }
+
+        self.mock_s3_control_client.get_access_grants_instance_for_prefix.return_value = {
+            'AccessGrantsInstanceArn': 'arn:aws:s3:us-east-2:987654321098:access-grants/default',
+            'AccessGrantsInstanceId': 'abcdefghijklmnopqrstuvwxyz'
+        }
+        requester_credentials = credentials.Credentials(access_key="access_key", secret_key="secret_key", token="token")
+        key = CacheKey(requester_credentials, 'READ', "s3://bucket-name/prefixA")
+        self.access_grants_cache.get_credentials(self.mock_s3_control_client, key,
+                                                 self.requester_account_id, self.access_denied_cache)
+        self.access_grants_cache.get_credentials(self.mock_s3_control_client, key,
+                                                 self.requester_account_id, self.access_denied_cache)
+        self.assertEqual(self.mock_s3_control_client.get_data_access.call_count, 2)
+
+    def test_which_s3_prefixes_stored_in_cache(self):
+        grant_1 = "s3://bucket/foo/bar/*"
+        grant_2 = "s3://bucket/foo/bar.txt"
+        grant_3 = "s3://*"
+        grant_4 = "s3://bucket/foo*"
+        self.assertEqual(self.access_grants_cache._AccessGrantsCache__process_matched_target(grant_1),
+                         "s3://bucket/foo/bar")
+        self.assertEqual(self.access_grants_cache._AccessGrantsCache__process_matched_target(grant_2),
+                         "s3://bucket/foo/bar.txt")
+        self.assertEqual(self.access_grants_cache._AccessGrantsCache__process_matched_target(grant_3),
+                         "s3:/")
+        self.assertEqual(self.access_grants_cache._AccessGrantsCache__process_matched_target(grant_4),
+                         "s3://bucket/foo*")
+
+    def test_cache_creation_with_invalid_cache_size(self):
+        with self.assertRaises(exceptions.IllegalArgumentException):
+            AccessGrantsCache(cache_size=1000001)
+
+    def test_cache_creation_with_invalid_duration(self):
+        with self.assertRaises(exceptions.IllegalArgumentException):
+            AccessGrantsCache(duration=4099000)
+
+    def test_cache_ttl(self):
+        access_grants_cache = AccessGrantsCache(duration=2)
+        requester_credentials = credentials.Credentials(access_key="access_key", secret_key="secret_key", token="token")
+        key = CacheKey(requester_credentials, 'READ', "s3://bucket-name/prefixA")
+        access_grants_cache._AccessGrantsCache__put_value_in_cache(key, self.access_grants_credentials)
+        time.sleep(2)
+        self.assertEqual(access_grants_cache._AccessGrantsCache__get_value_from_cache(key), None)
+

--- a/tests/unit/cache/test_account_id_resolver_cache.py
+++ b/tests/unit/cache/test_account_id_resolver_cache.py
@@ -18,10 +18,9 @@ class TestAccountIdResolverCache(unittest.TestCase):
                          "987654321098")
 
     # test to check if service call is made only once for every resolve call with the same bucket name
-    @mock.patch('AccountIdResolverCache.AccountIdResolverCache.resolve_from_service')
+    @mock.patch('account_id_resolver_cache.AccountIdResolverCache._AccountIdResolverCache__resolve_from_service')
     def test_count_resolve_method(self, mocked_resolve_from_service):
         cache = AccountIdResolverCache()
-        mocked_resolve_from_service.return_value = "987654321098"
         cache.resolve(self.mock_s3_control_client, "123456789012", "s3://bucketName/prefixA")
         cache.resolve(self.mock_s3_control_client, "123456789012", "s3://bucketName/prefixB")
         mocked_resolve_from_service.assert_called_once()
@@ -34,13 +33,13 @@ class TestAccountIdResolverCache(unittest.TestCase):
             'AccessGrantsInstanceId': 'abcdefghijklmnopqrstuvwxyz'
         }
         self.assertEqual(
-            cache.resolve_from_service(self.mock_s3_control_client, "123456789012", "s3://bucketName/prefixA"),
+            cache._AccountIdResolverCache__resolve_from_service(self.mock_s3_control_client, "123456789012", "s3://bucketName/prefixA"),
             "987654321098")
 
     # test to check if get_bucket_name method returns expected bucket name for s3 prefix
     def test_get_bucket_name(self):
         cache = AccountIdResolverCache()
-        self.assertEqual(cache.get_bucket_name("s3://bucketName/prefixA"), "bucketName")
+        self.assertEqual(cache._AccountIdResolverCache__get_bucket_name("s3://bucketName/prefixA"), "bucketName")
 
     # test to check if init method of AccountIdResolverCache throws IllegalArgumentException for invalid cache size
     def test_cache_creation_with_invalid_cache_size(self):

--- a/tests/unit/cache/test_cache_key.py
+++ b/tests/unit/cache/test_cache_key.py
@@ -1,31 +1,41 @@
 import unittest
-
 from botocore import credentials
-
 from cache_key import CacheKey
 
 
 class TestCacheKey(unittest.TestCase):
     # verify if both the keys are equal if they are equal in value not object id
     def test_cache_key_equals(self):
-        credentials1 = credentials.Credentials(access_key="access_key", secret_key="secret_key", token="token")
-        credentials2 = credentials.Credentials(access_key="access_key", secret_key="secret_key", token="token")
-        permission1 = 'READ'
-        permission2 = 'READ'
-        s3_prefix1 = "s3://s3-staircase-integration-sdkv2-codeshare/*"
-        s3_prefix2 = "s3://s3-staircase-integration-sdkv2-codeshare/*"
-        key1 = CacheKey(credentials1, permission1, s3_prefix1)
-        key2 = CacheKey(credentials2, permission2, s3_prefix2)
-        self.assertEqual(key1, key2)
+        credentials_1 = credentials.Credentials(access_key="access_key", secret_key="secret_key", token="token")
+        credentials_2 = credentials.Credentials(access_key="access_key", secret_key="secret_key", token="token")
+        permission_1 = 'READ'
+        permission_2 = 'READ'
+        s3_prefix_1 = "s3://bucket-name/*"
+        s3_prefix_2 = "s3://bucket-name/*"
+        key_1 = CacheKey(credentials_1, permission_1, s3_prefix_1)
+        key_2 = CacheKey(credentials_2, permission_2, s3_prefix_2)
+        self.assertEqual(key_1, key_2)
 
     # verify equals fails if the value is different for both the objects
     def test_cache_key_not_equals(self):
-        credentials1 = credentials.Credentials(access_key="access_key_1", secret_key="secret_key_1", token="token_1")
-        credentials2 = credentials.Credentials(access_key="access_key_2", secret_key="secret_key_2", token="token_2")
-        permission1 = 'READ'
-        permission2 = 'WRITE'
-        s3_prefix1 = "s3://s3-staircase-integration-sdkv2-codeshare/*"
-        s3_prefix2 = "s3://s3-staircase-integration-sdkv2-codeshare/*"
-        key1 = CacheKey(credentials1, permission1, s3_prefix1)
-        key2 = CacheKey(credentials2, permission2, s3_prefix2)
-        self.assertNotEqual(key1, key2)
+        credentials_1 = credentials.Credentials(access_key="access_key_1", secret_key="secret_key_1", token="token_1")
+        credentials_2 = credentials.Credentials(access_key="access_key_2", secret_key="secret_key_2", token="token_2")
+        permission_1 = 'READ'
+        permission_2 = 'WRITE'
+        s3_prefix_1 = "s3://bucket-name/*"
+        s3_prefix_2 = "s3://bucket-name/*"
+        key_1 = CacheKey(credentials_1, permission_1, s3_prefix_1)
+        key_2 = CacheKey(credentials_2, permission_2, s3_prefix_2)
+        self.assertNotEqual(key_1, key_2)
+
+    def test_cache_key_init_method(self):
+        requester_credentials = credentials.Credentials(access_key="access_key", secret_key="secret_key", token="token")
+        cache_key = CacheKey(requester_credentials, 'READ', "s3://bucket-name/*")
+        cache_key_1 = CacheKey(cache_key=cache_key, permission='WRITE')
+        cache_key_2 = CacheKey(cache_key=cache_key, s3_prefix="s3://*")
+        self.assertEqual(cache_key_1.credentials, cache_key.credentials)
+        self.assertEqual(cache_key_1.s3_prefix, cache_key.s3_prefix)
+        self.assertEqual(cache_key_1.permission, 'WRITE')
+        self.assertEqual(cache_key_2.credentials, cache_key.credentials)
+        self.assertEqual(cache_key_2.permission, cache_key.permission)
+        self.assertEqual(cache_key_2.s3_prefix, "s3://*")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Added Access Grant Cache. This cache caches the Access Grants credentials returned by the Access Grants service.
2. Added Access Denied Cache. This cache caches the Access Denied responses returned by the Access Grants service.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
