### PR TITLE
implement bucket region resolver cache

### DIFF
--- a/boto3_s3_access_grants_plugin/cache/bucket_region_resolver_cache.py
+++ b/boto3_s3_access_grants_plugin/cache/bucket_region_resolver_cache.py
@@ -17,10 +17,10 @@ class BucketRegionResolverCache:
         self.bucket_region_resolver_cache = Cache(maxsize=self.cache_size, ttl=self.cache_ttl)
 
     @staticmethod
-    def __resolve_from_service(s3_control_client, bucket):
+    def __resolve_from_service(s3_client, bucket):
         resolved_region = None
         try:
-            head_bucket_response = s3_control_client.head_bucket(Bucket=bucket)
+            head_bucket_response = s3_client.head_bucket(Bucket=bucket)
             resolved_region = head_bucket_response['BucketRegion']
         except ClientError as e:
             logging.debug("Client error when calling head bucket. Attempting to get region from request headers")
@@ -35,10 +35,10 @@ class BucketRegionResolverCache:
         return resolved_region
 
 
-    def resolve(self, s3_control_client, bucket):
+    def resolve(self, s3_client, bucket):
         bucket_region = self.bucket_region_resolver_cache.get(bucket)
         if bucket_region is None:
             logging.debug(f"Region for bucket \"{bucket}\" not available in cache. Fetching region from service")
-            bucket_region = BucketRegionResolverCache.__resolve_from_service(s3_control_client, bucket)
+            bucket_region = BucketRegionResolverCache.__resolve_from_service(s3_client, bucket)
             self.bucket_region_resolver_cache.set(bucket, bucket_region)
         return bucket_region

--- a/tests/unit/cache/test_bucket_region_resolver_cache.py
+++ b/tests/unit/cache/test_bucket_region_resolver_cache.py
@@ -4,31 +4,31 @@ from botocore.exceptions import ClientError
 from boto3_s3_access_grants_plugin.cache.bucket_region_resolver_cache import BucketRegionResolverCache
 
 class TestBucketRegionResolverCache(unittest.TestCase):
-    mock_s3_control_client = mock.Mock()
+    s3_client = mock.Mock()
 
     def __reset_mock(self):
-        self.mock_s3_control_client.reset_mock(return_value=True, side_effect=True)
+        self.s3_client.reset_mock(return_value=True, side_effect=True)
 
     def test_resolve(self):
         cache = BucketRegionResolverCache()
         expectedRegion = 'us-east-2'
-        self.mock_s3_control_client.head_bucket.return_value = {
+        self.s3_client.head_bucket.return_value = {
             'BucketRegion': expectedRegion,
         }
-        self.assertEqual(cache.resolve(self.mock_s3_control_client, 'fakebucket'), expectedRegion)
+        self.assertEqual(cache.resolve(self.s3_client, 'fakebucket'), expectedRegion)
         self.__reset_mock()
 
     @mock.patch('boto3_s3_access_grants_plugin.cache.bucket_region_resolver_cache.BucketRegionResolverCache._BucketRegionResolverCache__resolve_from_service')
     def test_resolve_caches_response(self, mocked_resolve_from_service):
         cache = BucketRegionResolverCache()
-        cache.resolve(self.mock_s3_control_client, 'fakebucket')
-        cache.resolve(self.mock_s3_control_client, 'fakebucket')
+        cache.resolve(self.s3_client, 'fakebucket')
+        cache.resolve(self.s3_client, 'fakebucket')
         mocked_resolve_from_service.assert_called_once()
 
     def test_service_redirect_with_header(self):
         cache = BucketRegionResolverCache()
         expectedRegion = 'us-east-2'
-        self.mock_s3_control_client.head_bucket.side_effect = ClientError(
+        self.s3_client.head_bucket.side_effect = ClientError(
             operation_name='head_bucket',
             error_response={
                 'ResponseMetaData': {
@@ -39,12 +39,12 @@ class TestBucketRegionResolverCache(unittest.TestCase):
                 }
             }
         )
-        self.assertEqual(cache.resolve(self.mock_s3_control_client, 'fakebucket'), expectedRegion)
+        self.assertEqual(cache.resolve(self.s3_client, 'fakebucket'), expectedRegion)
         self.__reset_mock()
 
     def test_service_redirect_without_header(self):
         cache = BucketRegionResolverCache()
-        self.mock_s3_control_client.head_bucket.side_effect = ClientError(
+        self.s3_client.head_bucket.side_effect = ClientError(
             operation_name='head_bucket',
             error_response={
                 'Error': {
@@ -59,13 +59,13 @@ class TestBucketRegionResolverCache(unittest.TestCase):
             }
         )
         with self.assertRaises(ClientError) as e:
-            cache.resolve(self.mock_s3_control_client, 'fakebucket')
+            cache.resolve(self.s3_client, 'fakebucket')
             self.assertEqual(e.response['Error']['Message'], 'Redirect')
         self.__reset_mock()
 
     def test_bucket_not_exists(self):
         cache = BucketRegionResolverCache()
-        self.mock_s3_control_client.head_bucket.side_effect = ClientError(
+        self.s3_client.head_bucket.side_effect = ClientError(
             operation_name='head_bucket',
             error_response= {
                 'Error': {
@@ -78,6 +78,6 @@ class TestBucketRegionResolverCache(unittest.TestCase):
             }
         )
         with self.assertRaises(ClientError) as e:
-            cache.resolve(self.mock_s3_control_client, 'fakebucket')
+            cache.resolve(self.s3_client, 'fakebucket')
             self.assertEqual(e.response['Error']['Message'], 'Bucket does not exist')
         self.__reset_mock()


### PR DESCRIPTION
*Description of changes:*
Implement Bucket Region Resolver Cache

General Workflow:
1. Attempt to fetch region for bucket from cache
2. If cache miss, call HeadBucket for bucketregion
3. If HeadBucket fails, we may still be able to get the bucket region from the HTTPHeader `x-amz-bucket-region`, such as in a redirect response

I did not bother testing the constructor and underlying cacheout implementation, but can add tests for configuring cache size and ttl if that's something we think is important

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
