### PR TITLE
added code to support customer session for internal clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.1.0 2024-09-04
+### Features
+* You can now pass a session while initiating the plugin. That session will be used to create s3, sts, and s3control clients internally.
+### Bugfix
+* Now you can get the prefix from ListObjects, ListObjectsV2, ListObjectVersions, and ListMultipartUploads  and you can call getDataAccess on that prefix.
+* Refactored private method names.
+---
+
 ## 1.0.1 2024-07-22
 ### Bugfix
 * Fixed dependency issue. Now you don't have to install dependencies separately.

--- a/README.md
+++ b/README.md
@@ -30,12 +30,11 @@ fallback_enabled takes in a boolean value. This option decides if we will fall b
 1. If fallback_enabled is set to True then we will fall back every time we are not able to get the credentials from Access Grants, no matter the reason.
 2. If fallback_enabled option is set to False we will fall back only in case the operation/API is not supported by Access Grants.
 
-customer_session is an optional parameter. This session will be used to create the internal sts, s3, and s3control clients. If no session is passed the default botocore session will be used to create these clients.
+customer_session is an optional parameter of type botocore.session.Session. This session will be used to create the internal sts, s3, and s3control clients. If no session is passed the default botocore session will be used to create these clients.
 
 ### Notes
 * The plugin supports delete_objects API and copy_object API which S3 Access Grants does not implicitly support. For these APIs we get the common prefix of all the object keys and find their common ancestor. If you  have a grant present on the common ancestor, you will get Access Grants credentials based on that grant.
 For copy_object API the source and destination buckets should be same, since a grant cannot give access to multiple buckets.
-* Currently, the plugin grants access to Amazon S3 bucket, prefix, or object via IAM principals only.
 
 ---
 ### Contributions

--- a/README.md
+++ b/README.md
@@ -22,13 +22,15 @@ from aws_s3_access_grants_boto3_plugin.s3_access_grants_plugin import S3AccessGr
 
 session = botocore.session.get_session()
 s3_client = session.create_client('s3')
-plugin = S3AccessGrantsPlugin(s3_client, fallback_enabled=True)
+plugin = S3AccessGrantsPlugin(s3_client, fallback_enabled=True, customer_session=session)
 plugin.register()
 ```
 
 fallback_enabled takes in a boolean value. This option decides if we will fall back to the credentials set on the S3 Client by the user.
 1. If fallback_enabled is set to True then we will fall back every time we are not able to get the credentials from Access Grants, no matter the reason.
 2. If fallback_enabled option is set to False we will fall back only in case the operation/API is not supported by Access Grants.
+
+customer_session is an optional parameter. This session will be used to create the internal sts, s3, and s3control clients. If no session is passed the default botocore session will be used to create these clients.
 
 ### Notes
 * The plugin supports delete_objects API and copy_object API which S3 Access Grants does not implicitly support. For these APIs we get the common prefix of all the object keys and find their common ancestor. If you  have a grant present on the common ancestor, you will get Access Grants credentials based on that grant.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aws_s3_access_grants_boto3_plugin"
-version = "1.0.1"
+version = "1.1.0"
 description = "AWS S3 Access Grants plugin provides the functionality to enable S3 customers to configure S3 Access Grants as a permission layer on top of the S3 Clients."
 readme = "README.md"
 requires-python = ">=3.8"
@@ -15,6 +15,7 @@ classifiers = [
 dependencies = [
     'cacheout>=0.16.0',
     'botocore>=1.34.70',
+    'boto3>=1.34.0'
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,7 @@ classifiers = [
 ]
 dependencies = [
     'cacheout>=0.16.0',
-    'botocore>=1.34.70',
-    'boto3>=1.34.0'
+    'botocore>=1.34.70'
 ]
 
 [project.urls]


### PR DESCRIPTION
*Description of changes:*
1. Customers can now pass in their session to create internal sts, s3, and s3control clients.
2. Added code to get the prefix from ListObjects, ListObjectsV2, ListObjectVersions, and ListMultipartUploads

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
