### PR TITLE
flipping the default fallback to False before public release

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ fallback_enabled takes in a boolean value. This option decides if we will fall b
 1. If fallback_enabled is set to True then we will fall back every time we are not able to get the credentials from Access Grants, no matter the reason.
 2. If fallback_enabled option is set to False we will fall back only in case the operation/API is not supported by Access Grants.
 
-Note that fallback_enabled can be passed while creating the plugin (as showed in example above). If fallback_enabled is not set, we will be defaulting to True.
+Note that fallback_enabled can be passed while creating the plugin (as showed in example above). If fallback_enabled is not set, we will default to False.
 
 customer_session is an optional parameter of type botocore.session.Session. This session will be used to create the internal sts, s3, and s3control clients. If no session is passed the default botocore session will be used to create these clients.
 

--- a/aws_s3_access_grants_boto3_plugin/s3_access_grants_plugin.py
+++ b/aws_s3_access_grants_boto3_plugin/s3_access_grants_plugin.py
@@ -21,7 +21,7 @@ class S3AccessGrantsPlugin:
     client_dict = {}
     session_config = botocore.config.Config(user_agent="aws_s3_access_grants_boto3_plugin")
 
-    def __init__(self, s3_client, fallback_enabled=True, customer_session=None):
+    def __init__(self, s3_client, fallback_enabled=False, customer_session=None):
         self.s3_client = s3_client
         self.fallback_enabled = fallback_enabled
 

--- a/tests/unit/test_s3_access_grants_plugin.py
+++ b/tests/unit/test_s3_access_grants_plugin.py
@@ -105,7 +105,7 @@ class TestS3AccessGrantsPlugin(unittest.TestCase):
         mock_plugin_class.assert_called_once_with(s3_client, fallback_enabled=True)
         mock_plugin_instance.register.assert_called_once()
 
-    def test_initializing_plugin_with_no_fallback_defaults_to_true(self):
+    def test_initializing_plugin_with_no_fallback_defaults_to_false(self):
         s3_client = self._create_mock_s3_client()
         plugin = S3AccessGrantsPlugin(s3_client)
-        self.assertTrue(plugin.fallback_enabled)
+        self.assertFalse(plugin.fallback_enabled)


### PR DESCRIPTION
*Description of changes:*

Switching the default fallback for the plugin to False.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
