### PR TITLE
Add optional auditContext parameter to GetDataAccess API call

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ from aws_s3_access_grants_boto3_plugin.s3_access_grants_plugin import S3AccessGr
 
 session = botocore.session.get_session()
 s3_client = session.create_client('s3')
-plugin = S3AccessGrantsPlugin(s3_client, fallback_enabled=True, customer_session=session)
+plugin = S3AccessGrantsPlugin(s3_client, fallback_enabled=True, customer_session=session, audit_context="my-query-id-12345")
 plugin.register()
 ```
 
@@ -33,6 +33,8 @@ fallback_enabled takes in a boolean value. This option decides if we will fall b
 Note that fallback_enabled can be passed while creating the plugin (as showed in example above). If fallback_enabled is not set, we will default to False.
 
 customer_session is an optional parameter of type botocore.session.Session. This session will be used to create the internal sts, s3, and s3control clients. If no session is passed the default botocore session will be used to create these clients.
+
+audit_context is an optional string parameter that provides additional context for CloudTrail audit logging. When provided, it is included in the `GetDataAccess` API call as the `AuditContext` parameter. This value is purely for auditing purposes and does not affect grant evaluation or credential caching. If not set, it defaults to None and is omitted from the API call.
 
 ### Notes
 * The plugin supports delete_objects API and copy_object API which S3 Access Grants does not implicitly support. For these APIs we get the common prefix of all the object keys and find their common ancestor. If you  have a grant present on the common ancestor, you will get Access Grants credentials based on that grant.

--- a/aws_s3_access_grants_boto3_plugin/cache/access_grants_cache.py
+++ b/aws_s3_access_grants_boto3_plugin/cache/access_grants_cache.py
@@ -57,7 +57,7 @@ class AccessGrantsCache:
             prefix = prefix[:-1]
         return None
 
-    def _get_credentials_from_service(self, s3_control_client, cache_key, account_id):
+    def _get_credentials_from_service(self, s3_control_client, cache_key, account_id, audit_context=None):
         if s3_control_client is None:
             raise IllegalArgumentException("S3 Control Client should not be null")
         bucket_owner_account_id = self.account_id_resolver_cache.resolve(s3_control_client, account_id,
@@ -65,8 +65,15 @@ class AccessGrantsCache:
         logging.debug((
                 "Fetching credentials from Access Grants for accountId: " + bucket_owner_account_id + ", s3Prefix: " + cache_key.s3_prefix +
                 ", permission: " + cache_key.permission + ", privilege: " + "DEFAULT"))
-        return s3_control_client.get_data_access(AccountId=bucket_owner_account_id, Target=cache_key.s3_prefix,
-                                                 Permission=cache_key.permission, Privilege='Default')
+        get_data_access_params = {
+            'AccountId': bucket_owner_account_id,
+            'Target': cache_key.s3_prefix,
+            'Permission': cache_key.permission,
+            'Privilege': 'Default',
+        }
+        if audit_context is not None:
+            get_data_access_params['AuditContext'] = audit_context
+        return s3_control_client.get_data_access(**get_data_access_params)
 
     # This method removes '/*' from matchedGrantTarget if present.
     # This helps us differentiate between grants of type "s3://bucket/prefix/*" and "s3://bucket/prefix*".
@@ -75,7 +82,7 @@ class AccessGrantsCache:
             return matched_grant_target[:-2]
         return matched_grant_target
 
-    def get_credentials(self, s3_control_client, cache_key, account_id, access_denied_cache):
+    def get_credentials(self, s3_control_client, cache_key, account_id, access_denied_cache, audit_context=None):
         logging.debug("Fetching credentials from Access Grants for s3Prefix: " + cache_key.s3_prefix)
         credentials = self._search_credentials_at_prefix_level(cache_key)
         if credentials is None and (cache_key.permission == "READ" or cache_key.permission == "WRITE"):
@@ -89,7 +96,7 @@ class AccessGrantsCache:
         if credentials is None:
             logging.debug("Credentials not available in the cache. Fetching credentials from Access Grants service.")
             try:
-                response = self._get_credentials_from_service(s3_control_client, cache_key, account_id)
+                response = self._get_credentials_from_service(s3_control_client, cache_key, account_id, audit_context=audit_context)
                 credentials = response["Credentials"]
                 matched_grant_target = response["MatchedGrantTarget"]
                 if matched_grant_target.endswith("*"):  # we do not cache object level grants

--- a/aws_s3_access_grants_boto3_plugin/s3_access_grants_plugin.py
+++ b/aws_s3_access_grants_boto3_plugin/s3_access_grants_plugin.py
@@ -21,9 +21,10 @@ class S3AccessGrantsPlugin:
     client_dict = {}
     session_config = botocore.config.Config(user_agent="aws_s3_access_grants_boto3_plugin")
 
-    def __init__(self, s3_client, fallback_enabled=False, customer_session=None):
+    def __init__(self, s3_client, fallback_enabled=False, customer_session=None, audit_context=None):
         self.s3_client = s3_client
         self.fallback_enabled = fallback_enabled
+        self.audit_context = audit_context
 
         if isinstance(customer_session, botocore.session.Session):
             self.session = customer_session
@@ -149,7 +150,8 @@ class S3AccessGrantsPlugin:
             raise access_denied_exception
         return self.access_grants_cache.get_credentials(s3_control_client, cache_key,
                                                         requester_account_id,
-                                                        self.access_denied_cache)
+                                                        self.access_denied_cache,
+                                                        audit_context=self.audit_context)
 
 
 def initialize_client_plugin(client):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 ]
 dependencies = [
     'cacheout>=0.16.0',
-    'botocore>=1.39.9'
+    'botocore>=1.42.80'
 ]
 
 [project.urls]

--- a/tests/integration/test_plugin.py
+++ b/tests/integration/test_plugin.py
@@ -89,6 +89,13 @@ class TestPlugin(unittest.TestCase):
                                                 Key=self.test_setup.TEST_LOCATION_2 + 'copiedFile.txt')
         self.assertEqual(response['ResponseMetadata']['HTTPStatusCode'], 204)
 
+    def test_grant_present_with_audit_context(self):
+        self.s3_client = self.session.create_client('s3')
+        self.plugin = S3AccessGrantsPlugin(self.s3_client, False, audit_context="integration-test-context")
+        self.plugin.register()
+        response = self.s3_client.get_object(Bucket=self.test_setup.registered_bucket_name, Key=self.test_setup.TEST_OBJECT_1)
+        self.assertEqual(response['ResponseMetadata']['HTTPStatusCode'], 200)
+
     def test_delete_objects_grant_present(self):
         self.createS3Client(enable_fallback=False)
         self.s3_client.put_object(Bucket=self.test_setup.registered_bucket_name,

--- a/tests/unit/cache/test_access_grants_cache.py
+++ b/tests/unit/cache/test_access_grants_cache.py
@@ -204,3 +204,68 @@ class TestAccessGrantsCache(unittest.TestCase):
         time.sleep(2)
         self.assertEqual(access_grants_cache._get_value_from_cache(key), None)
 
+    def test_get_credentials_from_service_with_audit_context(self):
+        self.mock_s3_control_client.get_data_access.return_value = {
+            'Credentials': {
+                'AccessKeyId': 'access_key_id',
+                'SecretAccessKey': 'secret_access_key',
+                'SessionToken': 'session_token',
+                'Expiration': datetime(2015, 1, 1)
+            },
+            'MatchedGrantTarget': 'string'
+        }
+        self.mock_s3_control_client.get_access_grants_instance_for_prefix.return_value = {
+            'AccessGrantsInstanceArn': 'arn:aws:s3:us-east-2:987654321098:access-grants/default',
+            'AccessGrantsInstanceId': 'abcdefghijklmnopqrstuvwxyz'
+        }
+        requester_credentials = credentials.Credentials(access_key="access_key", secret_key="secret_key", token="token")
+        key = CacheKey(requester_credentials, 'READ', "s3://bucket-name/prefixA")
+        self.access_grants_cache.get_credentials(self.mock_s3_control_client, key,
+                                                 self.requester_account_id, self.access_denied_cache,
+                                                 audit_context="test-audit-context")
+        call_kwargs = self.mock_s3_control_client.get_data_access.call_args
+        self.assertEqual(call_kwargs[1]['AuditContext'], 'test-audit-context')
+
+    def test_get_credentials_from_service_without_audit_context(self):
+        self.mock_s3_control_client.get_data_access.return_value = {
+            'Credentials': {
+                'AccessKeyId': 'access_key_id',
+                'SecretAccessKey': 'secret_access_key',
+                'SessionToken': 'session_token',
+                'Expiration': datetime(2015, 1, 1)
+            },
+            'MatchedGrantTarget': 'string'
+        }
+        self.mock_s3_control_client.get_access_grants_instance_for_prefix.return_value = {
+            'AccessGrantsInstanceArn': 'arn:aws:s3:us-east-2:987654321098:access-grants/default',
+            'AccessGrantsInstanceId': 'abcdefghijklmnopqrstuvwxyz'
+        }
+        requester_credentials = credentials.Credentials(access_key="access_key", secret_key="secret_key", token="token")
+        key = CacheKey(requester_credentials, 'READ', "s3://bucket-name/prefixA")
+        self.access_grants_cache.get_credentials(self.mock_s3_control_client, key,
+                                                 self.requester_account_id, self.access_denied_cache)
+        call_kwargs = self.mock_s3_control_client.get_data_access.call_args
+        self.assertNotIn('AuditContext', call_kwargs[1])
+
+    def test_get_credentials_from_service_with_none_audit_context(self):
+        self.mock_s3_control_client.get_data_access.return_value = {
+            'Credentials': {
+                'AccessKeyId': 'access_key_id',
+                'SecretAccessKey': 'secret_access_key',
+                'SessionToken': 'session_token',
+                'Expiration': datetime(2015, 1, 1)
+            },
+            'MatchedGrantTarget': 'string'
+        }
+        self.mock_s3_control_client.get_access_grants_instance_for_prefix.return_value = {
+            'AccessGrantsInstanceArn': 'arn:aws:s3:us-east-2:987654321098:access-grants/default',
+            'AccessGrantsInstanceId': 'abcdefghijklmnopqrstuvwxyz'
+        }
+        requester_credentials = credentials.Credentials(access_key="access_key", secret_key="secret_key", token="token")
+        key = CacheKey(requester_credentials, 'READ', "s3://bucket-name/prefixA")
+        self.access_grants_cache.get_credentials(self.mock_s3_control_client, key,
+                                                 self.requester_account_id, self.access_denied_cache,
+                                                 audit_context=None)
+        call_kwargs = self.mock_s3_control_client.get_data_access.call_args
+        self.assertNotIn('AuditContext', call_kwargs[1])
+

--- a/tests/unit/test_s3_access_grants_plugin.py
+++ b/tests/unit/test_s3_access_grants_plugin.py
@@ -109,3 +109,57 @@ class TestS3AccessGrantsPlugin(unittest.TestCase):
         s3_client = self._create_mock_s3_client()
         plugin = S3AccessGrantsPlugin(s3_client)
         self.assertFalse(plugin.fallback_enabled)
+
+    def test_initializing_plugin_with_audit_context(self):
+        s3_client = self._create_mock_s3_client()
+        plugin = S3AccessGrantsPlugin(s3_client, audit_context="test-audit-context")
+        self.assertEqual(plugin.audit_context, "test-audit-context")
+
+    def test_initializing_plugin_without_audit_context_defaults_to_none(self):
+        s3_client = self._create_mock_s3_client()
+        plugin = S3AccessGrantsPlugin(s3_client)
+        self.assertIsNone(plugin.audit_context)
+
+    @patch('aws_s3_access_grants_boto3_plugin.s3_access_grants_plugin.AccessGrantsCache.get_credentials')
+    def test_get_value_from_cache_passes_audit_context(self, get_credentials_mock):
+        s3_client = self._create_mock_s3_client()
+        s3_control_client = mock.Mock()
+        requester_credentials = credentials.Credentials(access_key="access_key", secret_key="secret_key", token="token")
+        cache_key = CacheKey(requester_credentials, 'READ', "s3://bucket/name")
+        access_grants_credentials = {
+            'Credentials': {
+                'AccessKeyId': 'access_key_id',
+                'SecretAccessKey': 'secret_access_key',
+                'SessionToken': 'session_token',
+                'Expiration': datetime(2015, 1, 1)
+            }
+        }
+        get_credentials_mock.return_value = access_grants_credentials
+        plugin = S3AccessGrantsPlugin(s3_client, False, audit_context="my-audit-context")
+        plugin._get_value_from_cache(cache_key, s3_control_client, '123456789012')
+        get_credentials_mock.assert_called_once_with(s3_control_client, cache_key,
+                                                     '123456789012',
+                                                     plugin.access_denied_cache,
+                                                     audit_context="my-audit-context")
+
+    @patch('aws_s3_access_grants_boto3_plugin.s3_access_grants_plugin.AccessGrantsCache.get_credentials')
+    def test_get_value_from_cache_passes_none_audit_context_when_not_set(self, get_credentials_mock):
+        s3_client = self._create_mock_s3_client()
+        s3_control_client = mock.Mock()
+        requester_credentials = credentials.Credentials(access_key="access_key", secret_key="secret_key", token="token")
+        cache_key = CacheKey(requester_credentials, 'READ', "s3://bucket/name")
+        access_grants_credentials = {
+            'Credentials': {
+                'AccessKeyId': 'access_key_id',
+                'SecretAccessKey': 'secret_access_key',
+                'SessionToken': 'session_token',
+                'Expiration': datetime(2015, 1, 1)
+            }
+        }
+        get_credentials_mock.return_value = access_grants_credentials
+        plugin = S3AccessGrantsPlugin(s3_client, False)
+        plugin._get_value_from_cache(cache_key, s3_control_client, '123456789012')
+        get_credentials_mock.assert_called_once_with(s3_control_client, cache_key,
+                                                     '123456789012',
+                                                     plugin.access_denied_cache,
+                                                     audit_context=None)


### PR DESCRIPTION
### Summary
- Add auditContext parameter to GetDataAccess API call. Currently Boto3 version 1.42.80 has the SDK change 
- Bump the minimum [botocore](https://github.com/boto/boto3) dependency in `pyproject.toml` from `>=1.39.9` to `>=1.42.80` to include `AuditContext` parameter. 
### Testing
- unit and Integration tests
